### PR TITLE
Fix some MDX syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Euribor Benchmark is defined as below
 
 All files in directory `data` are using the following naming convention pattern:
 
-    euribor-{maturity}-{granularity}.csv
+    euribor-&#123;maturity&#125;-&#123;granularity&#125;.csv
 
 For instance, you can have
 
@@ -44,5 +44,5 @@ This package includes a bash script executing two python scripts, one `scripts/s
 
 This Data Package is licensed by its maintainers under the [Public Domain Dedication and License PDDL](http://opendatacommons.org/licenses/pddl/1.0).
 
-Refer to the [terms of use](http://www.euribor-rates.eu/disclaimer.asp) of the source dataset for any specific restrictions on using these data in a public or commercial product. You should also be aware that this data comes indirectly from <http://www.emmi-benchmarks.eu/euribor-org/euribor-rates.html>.
+Refer to the [terms of use](http://www.euribor-rates.eu/disclaimer.asp) of the source dataset for any specific restrictions on using these data in a public or commercial product. You should also be aware that this data comes indirectly from [http://www.emmi-benchmarks.eu/euribor-org/euribor-rates.html](http://www.emmi-benchmarks.eu/euribor-org/euribor-rates.html).
 Note that underlying rights, terms and conditions in the data from the source are unclear and may exists.


### PR DESCRIPTION
Basically, curly braces can't be used like this in an MDX file. I used HTML code for '{' instead. Also, there was a wrong URL syntax `<URL>`.

### Error
![image](https://github.com/datasets/euribor/assets/67981832/eed7159f-8cb7-4e36-aaeb-87145c2e85a0)

### After the fix 
![image](https://github.com/datasets/euribor/assets/67981832/c1058904-5aef-405e-aa5b-91e588ec1533)
![image](https://github.com/datasets/euribor/assets/67981832/d4b27bb2-d72d-42b9-b044-704a1dc4494e)
